### PR TITLE
Save image button & Gamma correction rewrite.

### DIFF
--- a/src/main/java/net/bowen/draw/textures/Texture.java
+++ b/src/main/java/net/bowen/draw/textures/Texture.java
@@ -88,13 +88,6 @@ public void saveAsPNG(String filename) {
     ByteBuffer buffer = MemoryUtil.memAlloc(width * height * 3); // Assuming 3 bytes per pixel (RGB)
     try {
         glGetTexImage(GL_TEXTURE_2D, 0, GL_RGB, GL_UNSIGNED_BYTE, buffer);
-
-        // Apply gamma correction (2.2)
-        for (int i = 0; i < buffer.capacity(); i++) {
-            float corrected = (float) Math.pow((buffer.get(i) & 0xFF) / 255.0, 1.0 / 2.2) * 255.0f;
-            buffer.put(i, (byte) corrected);
-        }
-
         STBImageWrite.stbi_write_png(filename, width, height, 3, buffer, width * 3);
     } finally {
         MemoryUtil.memFree(buffer);

--- a/src/main/java/net/bowen/gui/GuiRenderer.java
+++ b/src/main/java/net/bowen/gui/GuiRenderer.java
@@ -9,6 +9,8 @@ public class GuiRenderer implements GuiLayer {
     private final int[] samplePerPixel = new int[1];
     private final int[] maxDepth = new int[1];
 
+    private String savedImagePath;
+
     public GuiRenderer(Window window) {
         this.window = window;
         raytraceExecutor = window.getRaytraceExecutor();
@@ -43,6 +45,14 @@ public class GuiRenderer implements GuiLayer {
         // Slider for max bounces of ray.
         if (ImGui.sliderInt("Max Depth", maxDepth, 1, 50)) {
             maxDepthUpdate();
+        }
+
+        // Save image button.
+        if (ImGui.button("Save Image")) {
+            savedImagePath = window.saveImage("image.png");
+        }
+        if (savedImagePath != null) {
+            ImGui.text("Image saved to: " + savedImagePath);
         }
     }
 

--- a/src/main/java/net/bowen/gui/Window.java
+++ b/src/main/java/net/bowen/gui/Window.java
@@ -4,10 +4,13 @@ import imgui.ImGui;
 import imgui.flag.ImGuiConfigFlags;
 import imgui.gl3.ImGuiImplGl3;
 import imgui.glfw.ImGuiImplGlfw;
-import net.bowen.draw.*;
+import net.bowen.draw.Scene;
 import net.bowen.draw.models.rasterization.Quad;
 import net.bowen.draw.textures.Texture;
-import net.bowen.system.*;
+import net.bowen.system.Deleteable;
+import net.bowen.system.RaytraceExecutor;
+import net.bowen.system.Shader;
+import net.bowen.system.ShaderProgram;
 import org.lwjgl.Version;
 import org.lwjgl.glfw.GLFWErrorCallback;
 import org.lwjgl.glfw.GLFWVidMode;
@@ -24,7 +27,6 @@ import static org.lwjgl.glfw.GLFW.*;
 import static org.lwjgl.opengl.GL11.*;
 import static org.lwjgl.opengl.GL15.GL_WRITE_ONLY;
 import static org.lwjgl.opengl.GL20.*;
-import static org.lwjgl.opengl.GL30.GL_FRAMEBUFFER_SRGB;
 import static org.lwjgl.opengl.GL30.GL_RGBA32F;
 import static org.lwjgl.opengl.GL43.GL_COMPUTE_SHADER;
 import static org.lwjgl.system.MemoryStack.stackPush;
@@ -156,9 +158,6 @@ public class Window {
         // creates the GLCapabilities instance and makes the OpenGL
         // bindings available for use.
         GL.createCapabilities();
-
-        // Gamma correction (gamma2.2)
-        glEnable(GL_FRAMEBUFFER_SRGB);
     }
 
     private void initImGui() {

--- a/src/main/java/net/bowen/gui/Window.java
+++ b/src/main/java/net/bowen/gui/Window.java
@@ -16,6 +16,7 @@ import org.lwjgl.system.MemoryStack;
 
 import java.awt.*;
 import java.awt.geom.AffineTransform;
+import java.io.File;
 import java.nio.IntBuffer;
 
 import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
@@ -31,7 +32,7 @@ import static org.lwjgl.system.MemoryUtil.NULL;
 
 public class Window {
     private final String title;
-    private final String outputFile;
+    private String outputFile;
     private final int sceneId;
     private final ImGuiImplGlfw imGuiGlfw = new ImGuiImplGlfw();
     private final ImGuiImplGl3 imGuiGl3 = new ImGuiImplGl3();
@@ -212,13 +213,25 @@ public class Window {
                 () -> System.out.println("All samples have completed in " + raytraceExecutor.getFinishTime() + " ms.")
         );
 
-        if (outputFile != null) {
-            raytraceExecutor.addCompleteListener(() -> {
-                System.out.println("Saving the result to " + outputFile + "...");
-                screenQuadTexture.saveAsPNG(outputFile);
-                System.out.println("Saved.");
-            });
-        }
+        if (outputFile != null)
+            raytraceExecutor.addCompleteListener(this::saveImage);
+    }
+
+    /**
+     * Immediately save the ray tracing result on {@link #screenQuadTexture} to the path provided in {@link #outputFile}.
+     * @return The absolute path string of the saved image.
+     */
+    private String saveImage() {
+        System.out.println("Saving the result to " + outputFile + "...");
+        screenQuadTexture.saveAsPNG(outputFile);
+        String absolutePath = new File(outputFile).getAbsolutePath();
+        System.out.println("A PNG file has been saved to: " + absolutePath);
+        return absolutePath;
+    }
+
+    public String saveImage(String outputFile) {
+        this.outputFile = outputFile;
+        return saveImage();
     }
 
     /**

--- a/src/main/resources/shaders/plainTextureShaders/frag.glsl
+++ b/src/main/resources/shaders/plainTextureShaders/frag.glsl
@@ -8,5 +8,8 @@ out vec4 frag_color;
 uniform sampler2D tex_sampler;
 
 void main() {
-    frag_color = texture(tex_sampler, varying_tex_coord);
+    vec4 texture_color = texture(tex_sampler, varying_tex_coord);
+
+    // Gamma correction
+    frag_color = pow(texture_color, vec4(1.0/2.2));
 }


### PR DESCRIPTION
I added a button for saving the render result to a PNG file. Users can originally save the render result by using the CLI arguments, and the image will save once all samples are finished. With this new button, users can save image during the rendering and can easily do that through the GUI.

I also moved the gamma correction code to the fragment shader. I used to use the GLFW built-in gamma correction function, but I would have to transform the colors when saving to PNG. By moving the code to the fragment shader, the progress becomes clean.